### PR TITLE
Allow SSH key change in setupssh command

### DIFF
--- a/evo_cli/cli.py
+++ b/evo_cli/cli.py
@@ -45,6 +45,7 @@ def main():  # pragma: no cover
         ssh_parser.add_argument('-H', '--host', help='SSH server hostname or IP address')
         ssh_parser.add_argument('-u', '--user', help='SSH username')
         ssh_parser.add_argument('-p', '--password', help='SSH password (not recommended, use interactive mode instead)')
+        ssh_parser.add_argument('-P', '--port', type=int, default=22, help='SSH port (default: 22)')
         ssh_parser.add_argument('-i', '--identity', help='Path to existing identity file to use')
         ssh_parser.add_argument('--help-examples', action='store_true', help='Show usage examples')
         

--- a/evo_cli/cli.py
+++ b/evo_cli/cli.py
@@ -10,8 +10,12 @@ Be creative! do whatever you want!
 
 import argparse
 import sys
-from evo_cli.ssh_setup import setup_ssh, show_usage as show_ssh_usage
-from evo_cli.miniconda_setup import install_miniconda, show_usage as show_miniconda_usage
+
+from evo_cli.miniconda_setup import install_miniconda
+from evo_cli.miniconda_setup import show_usage as show_miniconda_usage
+from evo_cli.ssh_setup import setup_ssh
+from evo_cli.ssh_setup import show_usage as show_ssh_usage
+
 
 def main():  # pragma: no cover
     """
@@ -30,45 +34,44 @@ def main():  # pragma: no cover
         * Run an application (Flask, FastAPI, Django, etc.)
     """
     parser = argparse.ArgumentParser(
-        description="EVO CLI - A collection of useful tools",
-        usage="evo <command> [<args>]"
+        description="EVO CLI - A collection of useful tools", usage="evo <command> [<args>]"
     )
     parser.add_argument("command", help="Command to run")
-    
+
     # Parse just the command argument
     args = parser.parse_args(sys.argv[1:2])
-    
+
     # Route to appropriate command handler
     if args.command == "setupssh":
         # Parse arguments for ssh setup
         ssh_parser = argparse.ArgumentParser(description="Set up SSH with key-based authentication")
-        ssh_parser.add_argument('-H', '--host', help='SSH server hostname or IP address')
-        ssh_parser.add_argument('-u', '--user', help='SSH username')
-        ssh_parser.add_argument('-p', '--password', help='SSH password (not recommended, use interactive mode instead)')
-        ssh_parser.add_argument('-P', '--port', type=int, default=22, help='SSH port (default: 22)')
-        ssh_parser.add_argument('-i', '--identity', help='Path to existing identity file to use')
-        ssh_parser.add_argument('--help-examples', action='store_true', help='Show usage examples')
-        
+        ssh_parser.add_argument("-H", "--host", help="SSH server hostname or IP address")
+        ssh_parser.add_argument("-u", "--user", help="SSH username")
+        ssh_parser.add_argument("-p", "--password", help="SSH password (not recommended, use interactive mode instead)")
+        ssh_parser.add_argument("-P", "--port", type=int, default=22, help="SSH port (default: 22)")
+        ssh_parser.add_argument("-i", "--identity", help="Path to existing identity file to use")
+        ssh_parser.add_argument("--help-examples", action="store_true", help="Show usage examples")
+
         ssh_args = ssh_parser.parse_args(sys.argv[2:])
-        
+
         if ssh_args.help_examples:
             show_ssh_usage()
             return
-            
+
         setup_ssh(ssh_args)
     elif args.command == "miniconda":
         # Parse arguments for miniconda installation
         miniconda_parser = argparse.ArgumentParser(description="Install Miniconda with OS-specific settings")
-        miniconda_parser.add_argument('-p', '--prefix', help='Installation directory')
-        miniconda_parser.add_argument('-f', '--force', action='store_true', help='Force reinstallation')
-        miniconda_parser.add_argument('--help-examples', action='store_true', help='Show usage examples')
-        
+        miniconda_parser.add_argument("-p", "--prefix", help="Installation directory")
+        miniconda_parser.add_argument("-f", "--force", action="store_true", help="Force reinstallation")
+        miniconda_parser.add_argument("--help-examples", action="store_true", help="Show usage examples")
+
         miniconda_args = miniconda_parser.parse_args(sys.argv[2:])
-        
+
         if miniconda_args.help_examples:
             show_miniconda_usage()
             return
-            
+
         install_miniconda(miniconda_args)
     else:
         print(f"Unknown command: {args.command}")

--- a/evo_cli/miniconda_setup.py
+++ b/evo_cli/miniconda_setup.py
@@ -1,14 +1,15 @@
 """Miniconda installation functionality for EVO CLI."""
+
 import os
 import platform
 import subprocess
 import tempfile
-import sys
-from pathlib import Path
+
 
 def show_usage():
     """Show usage examples for Miniconda installation."""
-    print("""
+    print(
+        """
 Miniconda Installation Script
 ============================
 
@@ -26,16 +27,20 @@ Examples:
   evo miniconda                      # Install with default settings
   evo miniconda -p /custom/path      # Install to a custom path
   evo miniconda -f                   # Force reinstallation
-""")
+"""
+    )
+
 
 def is_windows():
     """Check if the current OS is Windows."""
     return platform.system() == "Windows"
 
+
 def is_conda_installed(prefix):
     """Check if conda is already installed at the specified prefix."""
     conda_executable = os.path.join(prefix, "condabin", "conda.bat" if is_windows() else "conda")
     return os.path.exists(conda_executable)
+
 
 def get_default_install_path():
     """Get the default installation path based on the OS."""
@@ -43,6 +48,7 @@ def get_default_install_path():
         return os.path.join(os.environ.get("USERPROFILE", ""), "miniconda3")
     else:
         return os.path.join(os.path.expanduser("~"), "miniconda3")
+
 
 def install_miniconda_windows(prefix, force=False):
     """Install Miniconda on Windows."""
@@ -55,36 +61,31 @@ def install_miniconda_windows(prefix, force=False):
         # Create temp directory for the installer
         with tempfile.TemporaryDirectory() as temp_dir:
             installer_path = os.path.join(temp_dir, "miniconda_installer.exe")
-            
+
             # Download the installer
             print("Downloading Miniconda installer...")
+            url = "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe"
             download_cmd = [
-                "powershell", 
-                "-Command", 
-                f"Invoke-WebRequest -Uri https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -OutFile {installer_path}"
+                "powershell",
+                "-Command",
+                f"Invoke-WebRequest -Uri {url} -OutFile {installer_path}",
             ]
             subprocess.run(download_cmd, check=True)
-            
+
             # Run the installer silently
             print(f"Installing Miniconda to {prefix}...")
-            install_cmd = [
-                installer_path,
-                "/InstallationType=JustMe",
-                "/RegisterPython=0",
-                "/S",
-                "/D=" + prefix
-            ]
+            install_cmd = [installer_path, "/InstallationType=JustMe", "/RegisterPython=0", "/S", "/D=" + prefix]
             subprocess.run(install_cmd, check=True)
-            
+
             # Add to PATH using setx
             bin_dir = os.path.join(prefix, "Scripts")
             condabin_dir = os.path.join(prefix, "condabin")
-            
+
             # Get current PATH
             path_cmd = ["powershell", "-Command", "Write-Output $env:PATH"]
             result = subprocess.run(path_cmd, capture_output=True, text=True, check=True)
             current_path = result.stdout.strip()
-            
+
             # Only add to PATH if not already present
             if bin_dir not in current_path and condabin_dir not in current_path:
                 print("Adding Miniconda to PATH...")
@@ -94,10 +95,11 @@ def install_miniconda_windows(prefix, force=False):
             print("\nTo use conda, restart your terminal or run:")
             print(f"  {os.path.join(prefix, 'condabin', 'conda.bat')} init")
             return True
-            
+
     except Exception as e:
         print(f"Error installing Miniconda: {str(e)}")
         return False
+
 
 def install_miniconda_unix(prefix, force=False):
     """Install Miniconda on Linux/macOS."""
@@ -110,7 +112,7 @@ def install_miniconda_unix(prefix, force=False):
         # Create temp directory for the installer
         with tempfile.TemporaryDirectory() as temp_dir:
             installer_path = os.path.join(temp_dir, "miniconda.sh")
-            
+
             # Determine the correct installer based on platform
             if platform.system() == "Darwin":
                 if platform.machine() == "arm64":
@@ -122,52 +124,53 @@ def install_miniconda_unix(prefix, force=False):
                     installer_url = "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh"
                 else:
                     installer_url = "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
-            
+
             # Download the installer
             print("Downloading Miniconda installer...")
             download_cmd = ["wget", installer_url, "-O", installer_path]
             subprocess.run(download_cmd, check=True)
-            
+
             # Make the installer executable
             subprocess.run(["chmod", "+x", installer_path], check=True)
-            
+
             # Run the installer
             print(f"Installing Miniconda to {prefix}...")
             install_cmd = ["bash", installer_path, "-b", "-p", prefix]
             subprocess.run(install_cmd, check=True)
-            
+
             # Add to PATH if needed
             shell_rc_file = os.path.expanduser("~/.bashrc")
             if platform.system() == "Darwin":
                 if os.path.exists(os.path.expanduser("~/.zshrc")):
                     shell_rc_file = os.path.expanduser("~/.zshrc")
-                
+
             # Check if already in PATH
             with open(shell_rc_file, "r") as f:
                 content = f.read()
                 if prefix not in content:
                     print(f"Adding Miniconda to PATH in {shell_rc_file}...")
                     with open(shell_rc_file, "a") as f:
-                        f.write(f'\n# >>> conda initialize >>>\n')
+                        f.write("\n# >>> conda initialize >>>\n")
                         f.write(f'export PATH="{prefix}/bin:$PATH"\n')
-                        f.write(f'# <<< conda initialize <<<\n')
-            
+                        f.write("# <<< conda initialize <<<\n")
+
             print("\nMiniconda has been installed successfully!")
             print("\nTo use conda, restart your terminal or run:")
             print(f"  source {shell_rc_file}")
             return True
-            
+
     except Exception as e:
         print(f"Error installing Miniconda: {str(e)}")
         return False
+
 
 def install_miniconda(args):
     """Main function to install Miniconda based on the current OS."""
     # Get installation prefix
     prefix = args.prefix or get_default_install_path()
-    
+
     # Install based on OS
     if is_windows():
         return install_miniconda_windows(prefix, args.force)
     else:
-        return install_miniconda_unix(prefix, args.force) 
+        return install_miniconda_unix(prefix, args.force)

--- a/evo_cli/ssh_setup.py
+++ b/evo_cli/ssh_setup.py
@@ -1,4 +1,5 @@
 """SSH key setup functionality for EVO CLI."""
+
 import os
 import warnings
 
@@ -6,16 +7,18 @@ import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 try:
     from cryptography.utils import CryptographyDeprecationWarning
+
     warnings.filterwarnings("ignore", category=CryptographyDeprecationWarning)
 except ImportError:
     pass
 
-import paramiko
-import getpass
-import sys
-from pathlib import Path
-import subprocess
-import argparse
+import argparse  # noqa: E402
+import getpass  # noqa: E402
+import subprocess  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import paramiko  # noqa: E402
+
 
 def connect_ssh(hostname, username, password, port=22):
     """Connect to SSH server using provided credentials."""
@@ -28,74 +31,78 @@ def connect_ssh(hostname, username, password, port=22):
         port_info = f":{port}" if port != 22 else ""
         print(f"Connecting to {hostname}{port_info} as {username}...")
         client.connect(hostname=hostname, username=username, password=password, port=port)
-        
+
         print("Connection successful!")
-        
+
         # Execute a simple command to verify connection
         stdin, stdout, stderr = client.exec_command("hostname")
         result = stdout.read().decode().strip()
         print(f"Server hostname: {result}")
-        
+
         return client
     except Exception as e:
         print(f"Error connecting to SSH: {str(e)}")
         return None
+
 
 def ensure_ssh_key_exists():
     """Generate SSH key if it doesn't exist."""
     ssh_dir = Path.home() / ".ssh"
     id_rsa_path = ssh_dir / "id_rsa"
     id_rsa_pub_path = ssh_dir / "id_rsa.pub"
-    
+
     # Create .ssh directory if it doesn't exist
     os.makedirs(ssh_dir, exist_ok=True)
-    
+
     # Check if SSH key already exists
     if id_rsa_path.exists() and id_rsa_pub_path.exists():
         print("SSH key pair already exists.")
         return id_rsa_path, id_rsa_pub_path
-    
+
     # Generate SSH key pair
     print("Generating new SSH key pair...")
     try:
-        subprocess.run(['ssh-keygen', '-t', 'rsa', '-b', '4096', '-f', str(id_rsa_path), '-N', ''], 
-                      check=True, capture_output=True)
+        subprocess.run(
+            ["ssh-keygen", "-t", "rsa", "-b", "4096", "-f", str(id_rsa_path), "-N", ""], check=True, capture_output=True
+        )
         print(f"SSH key pair generated at {id_rsa_path}")
         return id_rsa_path, id_rsa_pub_path
     except Exception as e:
         print(f"Error generating SSH key: {str(e)}")
         return None, None
 
+
 def upload_ssh_key(client, pub_key_path):
     """Upload the public key to the remote server."""
     try:
         # Read public key content
-        with open(pub_key_path, 'r') as f:
+        with open(pub_key_path, "r") as f:
             pub_key_content = f.read().strip()
-        
+
         # Create ~/.ssh directory on remote server if it doesn't exist
         stdin, stdout, stderr = client.exec_command("mkdir -p ~/.ssh")
         if stderr.read():
             print(f"Error creating .ssh directory: {stderr.read().decode()}")
             return False
-        
+
         # Add the public key to authorized_keys
         stdin, stdout, stderr = client.exec_command(f"echo '{pub_key_content}' >> ~/.ssh/authorized_keys")
         if stderr.read():
             print(f"Error adding public key: {stderr.read().decode()}")
             return False
-        
+
         # Set proper permissions
         stdin, stdout, stderr = client.exec_command("chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys")
         if stderr.read():
             print(f"Error setting permissions: {stderr.read().decode()}")
             return False
-        
+
         print("SSH public key successfully uploaded to the server.")
         return True
     except Exception as e:
         print(f"Error uploading SSH key: {str(e)}")
         return False
+
 
 def save_to_ssh_config(hostname, username, identity_file, port=22):
     """Save SSH credentials to ~/.ssh/config file."""
@@ -115,19 +122,19 @@ Host {hostname}
 {port_line}  User {username}
   IdentityFile {identity_file}
 """
-        
+
         # Check if file exists and if the host is already configured
         if ssh_config_path.exists():
-            with open(ssh_config_path, 'r') as f:
+            with open(ssh_config_path, "r") as f:
                 content = f.read()
                 if f"Host {hostname}" in content:
                     print(f"Host {hostname} already exists in SSH config. Not modifying the file.")
                     return
-        
+
         # Append to existing file or create new one
-        with open(ssh_config_path, 'a+') as f:
+        with open(ssh_config_path, "a+") as f:
             f.write(config_entry)
-            
+
         print(f"SSH config saved to {ssh_config_path}")
         print("You can now connect without a password using:")
         print(f"  ssh {hostname}")
@@ -135,20 +142,21 @@ Host {hostname}
     except Exception as e:
         print(f"Error saving SSH config: {str(e)}")
 
+
 def setup_ssh(args=None):
     """Main function to set up SSH with key-based authentication."""
     # Parse command line arguments if provided
     if args is None:
-        parser = argparse.ArgumentParser(description='Set up SSH with key-based authentication.')
-        parser.add_argument('-H', '--host', help='SSH server hostname or IP address')
-        parser.add_argument('-u', '--user', help='SSH username')
-        parser.add_argument('-p', '--password', help='SSH password (not recommended, use interactive mode instead)')
-        parser.add_argument('-P', '--port', type=int, default=22, help='SSH port (default: 22)')
-        parser.add_argument('-i', '--identity', help='Path to existing identity file to use')
+        parser = argparse.ArgumentParser(description="Set up SSH with key-based authentication.")
+        parser.add_argument("-H", "--host", help="SSH server hostname or IP address")
+        parser.add_argument("-u", "--user", help="SSH username")
+        parser.add_argument("-p", "--password", help="SSH password (not recommended, use interactive mode instead)")
+        parser.add_argument("-P", "--port", type=int, default=22, help="SSH port (default: 22)")
+        parser.add_argument("-i", "--identity", help="Path to existing identity file to use")
         args = parser.parse_args()
 
     # Get port from args (default to 22)
-    port = getattr(args, 'port', 22) or 22
+    port = getattr(args, "port", 22) or 22
 
     # Get credentials from arguments or prompt the user
     if args.host and args.user and args.password:
@@ -164,13 +172,13 @@ def setup_ssh(args=None):
         hostname = args.host or input("Hostname/IP: ").strip()
         username = args.user or input("Username (default: root): ").strip() or "root"
         password = args.password or getpass.getpass("Password: ")
-        
+
         if not password:
             print("Password is required. Exiting.")
             return
-    
+
     # Ensure SSH key pair exists or use provided identity
-    if hasattr(args, 'identity') and args.identity:
+    if hasattr(args, "identity") and args.identity:
         private_key_path = Path(args.identity)
         public_key_path = Path(f"{args.identity}.pub")
         if not private_key_path.exists() or not public_key_path.exists():
@@ -182,7 +190,7 @@ def setup_ssh(args=None):
         if not private_key_path or not public_key_path:
             print("Failed to ensure SSH key exists. Exiting.")
             return
-    
+
     # Connect to SSH server
     client = connect_ssh(hostname, username, password, port)
     if not client:
@@ -199,9 +207,11 @@ def setup_ssh(args=None):
         client.close()
         print("Failed to set up passwordless authentication.")
 
+
 def show_usage():
     """Show usage examples."""
-    print("""
+    print(
+        """
 SSH Key Setup Script
 ===================
 
@@ -222,4 +232,5 @@ Usage examples:
 
   5. Use custom port with existing identity file:
      evo setupssh -H 42.96.16.233 -u root -p YourPassword -P 2222 -i /path/to/private_key
-""")
+"""
+    )

--- a/evo_cli/ssh_setup.py
+++ b/evo_cli/ssh_setup.py
@@ -222,4 +222,4 @@ Usage examples:
 
   5. Use custom port with existing identity file:
      evo setupssh -H 42.96.16.233 -u root -p YourPassword -P 2222 -i /path/to/private_key
-""") 
+""")

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,5 +6,6 @@ black
 isort
 pytest-cov
 mypy
+types-paramiko
 gitchangelog
 mkdocs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203


### PR DESCRIPTION
Allow users to specify a custom SSH port using -P/--port flag (default: 22). The port is used when connecting and saved to ~/.ssh/config when non-default.

### Summary :memo:
_Write an overview about it._

### Details
_Describe more what you did on changes._
1. (...)
2. (...)

### Bugfixes :bug: (delete if dind't have any)
-

### Checks
- [ ] Closed #798
- [ ] Tested Changes
- [ ] Stakeholder Approval
